### PR TITLE
Check for tmax if no host tree supplied

### DIFF
--- a/R/rcophylo.R
+++ b/R/rcophylo.R
@@ -90,6 +90,9 @@ rcophylo <- function(beta = 0.1,
                      timestep = 0.001) {
 
   if (is.null(HTree)) {   # simulate host tree along with parasite tree
+    if(is.null(tmax)) {
+      stop("if you don't supply a host tree you must include a tmax")
+    }
     if (!is.null(iniHBranch))
       warning("When no host tree is provided, any values for iniHBranch will be ignored.")
     if (!is.null(thetaS) || !is.null(thetaE)){ # parasite infection influences host extinction and/or speciation rate


### PR DESCRIPTION
Hi! Thank you so much for this useful package. 

My graduate student Breanna Sipley is using cophy to simulate and test some predictions of escape and radiate. We were getting errors looping through parameter values, and tracked it down to situations where we provided neither a Htree or a tmax. So, we added a small fix to return a more expressive error for this situation. 

Example:
`cop<-rcophylo(beta=0.1)`